### PR TITLE
Add file used for docker builds and deployments

### DIFF
--- a/DockerfileNitro
+++ b/DockerfileNitro
@@ -1,0 +1,23 @@
+FROM gliderlabs/alpine:3.4
+
+# Necessary depedencies
+RUN apk --update add bash curl tar
+
+# Install S6 from static bins
+RUN cd / && curl -L https://github.com/just-containers/skaware/releases/download/v1.17.1/s6-eeb0f9098450dbe470fc9b60627d15df62b04239-linux-amd64-bin.tar.gz | tar -xvzf -
+
+COPY traefik /bin/traefik
+
+COPY s6 /etc
+
+RUN chmod +x /etc/services/traefik.svc/run
+
+RUN chmod +x /etc/services/.s6-svscan/crash
+
+RUN chmod +x /etc/services/.s6-svscan/finish
+
+EXPOSE 8000
+EXPOSE 443
+EXPOSE 80
+
+CMD ["/bin/s6-svscan", "/etc/services"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+die() {
+    echo $1
+    exit 1
+}
+
+CGO_ENABLED=0 GOOS=linux go build
+
+file traefik | grep "ELF.*LSB" || die "../traefik is missing or not a Linux binary"
+
+CURRENT_REVISION=$(git rev-parse --short HEAD)
+docker build -t gonitro/traefik:${CURRENT_REVISION} -f DockerfileNitro . || die "Failed to build container"
+docker push gonitro/traefik:${CURRENT_REVISION}

--- a/s6/services/.s6-svscan/crash
+++ b/s6/services/.s6-svscan/crash
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Container crashed"

--- a/s6/services/.s6-svscan/finish
+++ b/s6/services/.s6-svscan/finish
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Container shutting down"

--- a/s6/services/traefik.svc/run
+++ b/s6/services/traefik.svc/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+exec 2>&1
+cd /bin
+echo -n "Starting Traefik"
+exec ./traefik


### PR DESCRIPTION
This is what I've been using locally to build and deploy a traefik image.  It should look familiar (tweety, sidecar)

- Nitro Dockerfile to build a traefik image using s6

- Necessary S6 files

- build.sh for convenience

ping @mihaitodor @relistan @felixgborrego  
