### PR TITLE
Add error page feature to Traefik

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -25,23 +25,23 @@ type TraefikConfiguration struct {
 // GlobalConfiguration holds global configuration (with providers, etc.).
 // It's populated from the traefik configuration file passed as an argument to the binary.
 type GlobalConfiguration struct {
-	GraceTimeOut              flaeg.Duration     `short:"g" description:"Duration to give active requests a chance to finish during hot-reload"`
-	Debug                     bool               `short:"d" description:"Enable debug mode"`
-	CheckNewVersion           bool               `description:"Periodically check if a new version has been released"`
-	AccessLogsFile            string             `description:"Access logs file"`
-	TraefikLogsFile           string             `description:"Traefik logs file"`
-	LogLevel                  string             `short:"l" description:"Log level"`
-	EntryPoints               EntryPoints        `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'"`
-	Cluster                   *types.Cluster     `description:"Enable clustering"`
-	Constraints               types.Constraints  `description:"Filter services by constraint, matching with service tags"`
-	ACME                      *acme.ACME         `description:"Enable ACME (Let's Encrypt): automatic SSL"`
-	DefaultEntryPoints        DefaultEntryPoints `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
-	ProvidersThrottleDuration flaeg.Duration     `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
-	MaxIdleConnsPerHost       int                `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
-	IdleTimeout               flaeg.Duration     `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
-	InsecureSkipVerify        bool               `description:"Disable SSL certificate verification"`
-	Retry                     *Retry             `description:"Enable retry sending request if network error"`
-	ErrorPages                *middlewares.ErrorPages
+	GraceTimeOut              flaeg.Duration          `short:"g" description:"Duration to give active requests a chance to finish during hot-reload"`
+	Debug                     bool                    `short:"d" description:"Enable debug mode"`
+	CheckNewVersion           bool                    `description:"Periodically check if a new version has been released"`
+	AccessLogsFile            string                  `description:"Access logs file"`
+	TraefikLogsFile           string                  `description:"Traefik logs file"`
+	LogLevel                  string                  `short:"l" description:"Log level"`
+	EntryPoints               EntryPoints             `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'"`
+	Cluster                   *types.Cluster          `description:"Enable clustering"`
+	Constraints               types.Constraints       `description:"Filter services by constraint, matching with service tags"`
+	ACME                      *acme.ACME              `description:"Enable ACME (Let's Encrypt): automatic SSL"`
+	DefaultEntryPoints        DefaultEntryPoints      `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
+	ProvidersThrottleDuration flaeg.Duration          `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
+	MaxIdleConnsPerHost       int                     `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
+	IdleTimeout               flaeg.Duration          `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
+	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
+	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
+	ErrorPages                *middlewares.ErrorPages `description:"Enable the use of a custom error page"`
 	Docker                    *provider.Docker        `description:"Enable Docker backend"`
 	File                      *provider.File          `description:"Enable File backend"`
 	Web                       *WebProvider            `description:"Enable Web backend"`

--- a/configuration.go
+++ b/configuration.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containous/flaeg"
 	"github.com/containous/traefik/acme"
+	"github.com/containous/traefik/middlewares"
 	"github.com/containous/traefik/provider"
 	"github.com/containous/traefik/types"
 )
@@ -24,22 +25,23 @@ type TraefikConfiguration struct {
 // GlobalConfiguration holds global configuration (with providers, etc.).
 // It's populated from the traefik configuration file passed as an argument to the binary.
 type GlobalConfiguration struct {
-	GraceTimeOut              flaeg.Duration          `short:"g" description:"Duration to give active requests a chance to finish during hot-reload"`
-	Debug                     bool                    `short:"d" description:"Enable debug mode"`
-	CheckNewVersion           bool                    `description:"Periodically check if a new version has been released"`
-	AccessLogsFile            string                  `description:"Access logs file"`
-	TraefikLogsFile           string                  `description:"Traefik logs file"`
-	LogLevel                  string                  `short:"l" description:"Log level"`
-	EntryPoints               EntryPoints             `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'"`
-	Cluster                   *types.Cluster          `description:"Enable clustering"`
-	Constraints               types.Constraints       `description:"Filter services by constraint, matching with service tags"`
-	ACME                      *acme.ACME              `description:"Enable ACME (Let's Encrypt): automatic SSL"`
-	DefaultEntryPoints        DefaultEntryPoints      `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
-	ProvidersThrottleDuration flaeg.Duration          `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
-	MaxIdleConnsPerHost       int                     `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
-	IdleTimeout               flaeg.Duration          `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
-	InsecureSkipVerify        bool                    `description:"Disable SSL certificate verification"`
-	Retry                     *Retry                  `description:"Enable retry sending request if network error"`
+	GraceTimeOut              flaeg.Duration     `short:"g" description:"Duration to give active requests a chance to finish during hot-reload"`
+	Debug                     bool               `short:"d" description:"Enable debug mode"`
+	CheckNewVersion           bool               `description:"Periodically check if a new version has been released"`
+	AccessLogsFile            string             `description:"Access logs file"`
+	TraefikLogsFile           string             `description:"Traefik logs file"`
+	LogLevel                  string             `short:"l" description:"Log level"`
+	EntryPoints               EntryPoints        `description:"Entrypoints definition using format: --entryPoints='Name:http Address::8000 Redirect.EntryPoint:https' --entryPoints='Name:https Address::4442 TLS:tests/traefik.crt,tests/traefik.key;prod/traefik.crt,prod/traefik.key'"`
+	Cluster                   *types.Cluster     `description:"Enable clustering"`
+	Constraints               types.Constraints  `description:"Filter services by constraint, matching with service tags"`
+	ACME                      *acme.ACME         `description:"Enable ACME (Let's Encrypt): automatic SSL"`
+	DefaultEntryPoints        DefaultEntryPoints `description:"Entrypoints to be used by frontends that do not specify any entrypoint"`
+	ProvidersThrottleDuration flaeg.Duration     `description:"Backends throttle duration: minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time."`
+	MaxIdleConnsPerHost       int                `description:"If non-zero, controls the maximum idle (keep-alive) to keep per-host.  If zero, DefaultMaxIdleConnsPerHost is used"`
+	IdleTimeout               flaeg.Duration     `description:"maximum amount of time an idle (keep-alive) connection will remain idle before closing itself."`
+	InsecureSkipVerify        bool               `description:"Disable SSL certificate verification"`
+	Retry                     *Retry             `description:"Enable retry sending request if network error"`
+	ErrorPages                *middlewares.ErrorPages
 	Docker                    *provider.Docker        `description:"Enable Docker backend"`
 	File                      *provider.File          `description:"Enable File backend"`
 	Web                       *WebProvider            `description:"Enable Web backend"`

--- a/middlewares/error_pages.go
+++ b/middlewares/error_pages.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/prometheus/common/log"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -22,7 +21,6 @@ func NewErrorPagesHandler(errorPage string) utils.ErrorHandler {
 }
 
 func (ep *ErrorPages) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
-	log.Errorln(err)
 	statusCode := http.StatusInternalServerError
 	if e, ok := err.(net.Error); ok {
 		if e.Timeout() {

--- a/middlewares/error_pages.go
+++ b/middlewares/error_pages.go
@@ -1,0 +1,42 @@
+package middlewares
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/prometheus/common/log"
+	"github.com/vulcand/oxy/utils"
+)
+
+type ErrorPages struct {
+	ErrorPage string
+}
+
+func NewErrorPagesHandler(errorPage string) utils.ErrorHandler {
+	if _, err := os.Stat(errorPage); err == nil {
+		return &ErrorPages{errorPage}
+	}
+	return &ErrorPages{}
+}
+
+func (ep *ErrorPages) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
+	log.Errorln(err)
+	statusCode := http.StatusInternalServerError
+	if e, ok := err.(net.Error); ok {
+		if e.Timeout() {
+			statusCode = http.StatusGatewayTimeout
+		} else {
+			statusCode = http.StatusBadGateway
+		}
+	} else if err == io.EOF {
+		statusCode = http.StatusBadGateway
+	}
+	w.WriteHeader(statusCode)
+	if statusCode >= 500 && statusCode < 600 && ep.ErrorPage != "" {
+		http.ServeFile(w, req, ep.ErrorPage)
+	} else {
+		w.Write([]byte(http.StatusText(statusCode)))
+	}
+}

--- a/middlewares/error_pages_test.go
+++ b/middlewares/error_pages_test.go
@@ -1,0 +1,26 @@
+package middlewares
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorPage(t *testing.T) {
+	handler := NewErrorPagesHandler("Dummy_file")
+	rr := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	handler.ServeHTTP(rr, req, err)
+	assert.Equal(t, rr.Code, http.StatusInternalServerError, "They should be equal")
+	assert.Equal(t, string("Internal Server Error"), rr.Result().Status, "They should be equal")
+
+	handler = NewErrorPagesHandler("testdata/error_page_testdata.html")
+	rr = httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "http://example.com", nil)
+	handler.ServeHTTP(rr, req, err)
+	responseData, _ := ioutil.ReadAll(rr.Result().Body)
+	assert.Equal(t, string("Error Page Test Data\n"), string(responseData), "They should be equal")
+}

--- a/middlewares/testdata/error_page_testdata.html
+++ b/middlewares/testdata/error_page_testdata.html
@@ -1,0 +1,1 @@
+Error Page Test Data

--- a/server.go
+++ b/server.go
@@ -564,6 +564,11 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 
 	backendsHealthcheck := map[string]*healthcheck.BackendHealthCheck{}
 
+	var errorPageHandler utils.ErrorHandler
+	if globalConfiguration.ErrorPages != nil {
+		errorPageHandler = middlewares.NewErrorPagesHandler(globalConfiguration.ErrorPages.ErrorPage)
+	}
+
 	backend2FrontendMap := map[string]string{}
 	for _, configuration := range configurations {
 		frontendNames := sortedFrontendNamesForConfig(configuration)
@@ -574,6 +579,10 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 			log.Debugf("Creating frontend %s", frontendName)
 
 			fwd, err := forward.New(forward.Logger(oxyLogger), forward.PassHostHeader(frontend.PassHostHeader))
+			if globalConfiguration.ErrorPages != nil {
+				fwd, err = forward.New(forward.Logger(oxyLogger), forward.PassHostHeader(frontend.PassHostHeader), forward.ErrorHandler(errorPageHandler))
+			}
+
 			if err != nil {
 				log.Errorf("Error creating forwarder for frontend %s: %v", frontendName, err)
 				log.Errorf("Skipping frontend %s...", frontendName)
@@ -619,6 +628,10 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 						log.Debugf("Creating backend %s", frontend.Backend)
 						var lb http.Handler
 						rr, _ := roundrobin.New(saveBackend)
+						if globalConfiguration.ErrorPages != nil {
+							rr, _ = roundrobin.New(saveBackend, roundrobin.ErrorHandler(errorPageHandler))
+						}
+
 						if configuration.Backends[frontend.Backend] == nil {
 							log.Errorf("Undefined backend '%s' for frontend %s", frontend.Backend, frontendName)
 							log.Errorf("Skipping frontend %s...", frontendName)
@@ -681,6 +694,7 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 								log.Debugf("Sticky session with cookie %v", cookiename)
 								rr, _ = roundrobin.New(saveBackend, roundrobin.EnableStickySession(sticky))
 							}
+
 							lb = rr
 							for serverName, server := range configuration.Backends[frontend.Backend].Servers {
 								url, err := url.Parse(server.URL)


### PR DESCRIPTION
To address [JIRA 3328](https://jira.gonitrocorp.com/browse/ENG-3328) and since the custom error page isn't an existing Traefik feature
- Add ErrorPages handler for serving custom error page
- Add error page handler to frontend forwarder
- Add error page handler to backend loadbalancer
- expose optional configuration in traefik.toml
- Unit tests to ensure page is being served correctly 

@felixgborrego @relistan @mihaitodor Do you guys mind having a look?