### PR TITLE
Refactor deprecated Transport.CancelRequest method

### DIFF
--- a/provider/sidecar_test.go
+++ b/provider/sidecar_test.go
@@ -370,7 +370,6 @@ func TestSidecar(t *testing.T) {
 
 			So(configMsg.Configuration.Backends, ShouldContainKey, "api")
 			So(configMsg.Configuration.Backends["api"].Servers["another-aws-host_9000"].URL, ShouldEqual, "http://169.254.1.1:9000")
-
 		})
 
 		Reset(func() {


### PR DESCRIPTION
- Use context.WithCancel to cancel the watcher http request
- Refactor code to allow closing the request body in a sane way
- Declare variables in the narrowest possible scope

Relevant discussions [here](https://github.com/Nitro/traefik/pull/8#discussion_r113911181) and [here](https://github.com/Nitro/traefik/pull/7/files#r113909951).