### PR TITLE
Use hardcoded default values for MaxConn fields

### DIFF
--- a/provider/sidecar.go
+++ b/provider/sidecar.go
@@ -143,11 +143,18 @@ func (provider *Sidecar) constructConfig(sidecarStates *catalog.ServicesState) (
 
 		if backend, ok := sidecarConfig.Backends[name]; ok {
 			backend.MaxConn = frontend.MaxConn
-
 			if backend.MaxConn == nil {
 				backend.MaxConn = &types.MaxConn{
 					Amount:        defaultMaxConnAmount,
 					ExtractorFunc: defaultMaxConnExtractorFunc,
+				}
+			} else {
+				if backend.MaxConn.Amount == 0 {
+					backend.MaxConn.Amount = defaultMaxConnAmount
+				}
+
+				if backend.MaxConn.ExtractorFunc == "" {
+					backend.MaxConn.ExtractorFunc = defaultMaxConnExtractorFunc
 				}
 			}
 

--- a/provider/testdata/sidecar_testdata.toml
+++ b/provider/testdata/sidecar_testdata.toml
@@ -11,3 +11,13 @@
     [frontends.api]
         backend = "api"
         passHostHeader = true
+    [frontends.maxconn_amount_only]
+        backend = "maxconn_amount_only"
+        passHostHeader = true
+        [frontends.maxconn_amount_only.maxconn]
+            amount = 42
+    [frontends.maxconn_extractorfunc_only]
+        backend = "maxconn_extractorfunc_only"
+        passHostHeader = true
+        [frontends.maxconn_extractorfunc_only.maxconn]
+            extractorfunc = "client.ip"


### PR DESCRIPTION
- Use hardcoded default values for the MaxConn fields if the user omits any of them when defining a frontend

- Enhance unit tests to exercise this behaviour

(cc @relistan @bparli)