### PR TITLE
Fix tick format for the Oy scale for Conn Counts

### DIFF
--- a/webui/src/app/sections/conn_stats/conn_stats.controller.js
+++ b/webui/src/app/sections/conn_stats/conn_stats.controller.js
@@ -53,6 +53,9 @@ function ConnStatsController($scope, $interval, $log, $filter, ConnStats) {
       },
       x: function(d) { return d.label; },
       y: function(d) { return d.value; },
+      yAxis: {
+        tickFormat: d3.format('d')
+      },
       valueFormat: d3.format('d'),
       showValues: true,
       rotateLabels: 90


### PR DESCRIPTION
Small cosmetic change: Use decimal format instead of float for the Oy scale ticks for the Current Connection Counts chart.

cc @bparli