### PR TITLE
Fix connlimit crash

### DIFF
--- a/server.go
+++ b/server.go
@@ -89,7 +89,6 @@ func NewServer(globalConfiguration GlobalConfiguration) *Server {
 		// leadership creation if cluster mode
 		server.leadership = cluster.NewLeadership(server.routinesPool.Ctx(), globalConfiguration.Cluster)
 	}
-	server.backendConnLimits = make(map[string]*connlimit.ConnLimiter)
 
 	return server
 }

--- a/server.go
+++ b/server.go
@@ -566,6 +566,9 @@ func (server *Server) loadConfig(configurations configs, globalConfiguration Glo
 
 	backendsHealthcheck := map[string]*healthcheck.BackendHealthCheck{}
 
+	// Clean up the backendConnLimits map each time we reload the config
+	server.backendConnLimits = make(map[string]*connlimit.ConnLimiter)
+
 	var errorPageHandler utils.ErrorHandler
 	if globalConfiguration.ErrorPages != nil {
 		errorPageHandler = middlewares.NewErrorPagesHandler(globalConfiguration.ErrorPages.ErrorPage)

--- a/web.go
+++ b/web.go
@@ -379,9 +379,14 @@ func (provider *WebProvider) getConnStatsHandler(response http.ResponseWriter, r
 		for b := range currentConfigurations[p].Backends {
 			if connLimiter, ok := provider.server.backendConnLimits[b]; ok {
 				if totalConn, ok := getTotalConn(connLimiter); ok {
-					payload[p].Backends[b] = connStats{
-						MaxConn:   currentConfigurations[p].Backends[b].MaxConn.Amount,
-						TotalConn: totalConn,
+					// Make sure that the current configuration contains this backend before trying to read it
+					if currentBackend, ok := currentConfigurations[p].Backends[b]; ok {
+						if currentBackend.MaxConn != nil {
+							payload[p].Backends[b] = connStats{
+								MaxConn:   currentBackend.MaxConn.Amount,
+								TotalConn: totalConn,
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
We need to clear the backendConnLimits map when we're hot reloading the server configuration. I also added a few extra checks to the conn stats HTTP handler to make it more resilient.